### PR TITLE
Add Arago report compile workflow

### DIFF
--- a/.github/workflows/1-arago-latex.yml
+++ b/.github/workflows/1-arago-latex.yml
@@ -1,0 +1,25 @@
+name: Compile Arago spot report
+
+on:
+  push:
+    branches:
+      - arago-florian
+    paths:
+      - 1-arago/report
+  workflow_dispatch:
+
+jobs:
+  arago-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up repo
+        uses: actions/checkout@v4
+      - name: Compile LaTeX report
+        uses: xu-cheng/latex-action@v3
+        with:
+          root_file: 1-arago/report/main.tex
+      - name: Upload PDF
+        uses: actions/upload-artifact@v4
+        with:
+          name: 1-arago-report
+          path: 1-arago/report/main.pdf


### PR DESCRIPTION
This workflow automatically compiles the Arago spot report and uploads it as an artifact whenever changes to 1-arago/report folder are pushed